### PR TITLE
Use Fluent::Plugin::Output instead of Fluent::Output

### DIFF
--- a/lib/fluent/plugin/out_pgjson.rb
+++ b/lib/fluent/plugin/out_pgjson.rb
@@ -5,7 +5,7 @@ require 'json'
 
 module Fluent::Plugin
 
-class PgJsonOutput < Fluent::Output
+class PgJsonOutput < Fluent::Plugin::Output
   Fluent::Plugin.register_output('pgjson', self)
 
   helpers :compat_parameters


### PR DESCRIPTION
Because Fluent::Output is compatible layer for old API.