### PR TITLE
Fix for #27: Plugin loses connection to postgres

### DIFF
--- a/lib/fluent/plugin/out_pgjson.rb
+++ b/lib/fluent/plugin/out_pgjson.rb
@@ -100,8 +100,10 @@ module Fluent::Plugin
       else
         @conn.put_copy_end
         res = @conn.get_result
-        @conn.close()
-        @conn = nil
+        if res.result_status!=PG::PGRES_COMMAND_OK
+          @conn.close()
+          @conn = nil
+        end
         raise res.result_error_message if res.result_status!=PG::PGRES_COMMAND_OK
       end
     end

--- a/lib/fluent/plugin/out_pgjson.rb
+++ b/lib/fluent/plugin/out_pgjson.rb
@@ -95,13 +95,13 @@ module Fluent::Plugin
         @conn.put_copy_end( errmsg )
         @conn.get_result
         @conn.close()
-	@conn = nil
+        @conn = nil
         raise
       else
         @conn.put_copy_end
         res = @conn.get_result
-	@conn.close()
-	@conn = nil
+        @conn.close()
+        @conn = nil
         raise res.result_error_message if res.result_status!=PG::PGRES_COMMAND_OK
       end
     end

--- a/lib/fluent/plugin/out_pgjson.rb
+++ b/lib/fluent/plugin/out_pgjson.rb
@@ -94,10 +94,14 @@ module Fluent::Plugin
         errmsg = "%s while copy data: %s" % [ err.class.name, err.message ]
         @conn.put_copy_end( errmsg )
         @conn.get_result
+        @conn.close()
+	@conn = nil
         raise
       else
         @conn.put_copy_end
         res = @conn.get_result
+	@conn.close()
+	@conn = nil
         raise res.result_error_message if res.result_status!=PG::PGRES_COMMAND_OK
       end
     end


### PR DESCRIPTION

I noticed the postgres connection is setup once and then it is assumed the connection will stay up forever, which is obviously not the case especially in cloud environment.

This fix will - upon exception - reset the postgres connection reference variable. It will then rely on FluentD retry logic to call the plugin write again. Retry is standard in FluentD so unless it is disabled this fix should work.

The next time that FluentD attempts write the Postgres connection is NIL, so a connection will be reestablished. 

I haven't seen a permanent connection loss anymore with this fix.

Disclaimer: I am not a ruby programmer so there might be a more graceful way to handle this variable reset but on the face of it it seemed the correct thing to do.