### PR TITLE
Tweak Travis CI job settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 
 rvm:
-  - 2.2
-  - 2.3
   - 2.4
   - 2.5
+  - 2.6
+  - 2.7.1
 
 addons:
   postgresql: "9.6"


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>

The latest Fluentd dropped to support Ruby 2.3 or older.
