### PR TITLE
check connection status befor the put_copy_end method

### DIFF
--- a/lib/fluent/plugin/out_pgjson.rb
+++ b/lib/fluent/plugin/out_pgjson.rb
@@ -95,9 +95,12 @@ module Fluent::Plugin
         @conn = nil
         raise
       rescue => err
-        errmsg = "%s while copy data: %s" % [ err.class.name, err.message ]
-        @conn.put_copy_end( errmsg )
-        @conn.get_result
+        conn_status = @conn.status
+        if conn_status==PG::CONNECTION_OK
+            errmsg = "%s while copy data: %s" % [ err.class.name, err.message ]
+            @conn.put_copy_end( errmsg )
+            @conn.get_result
+        end
         @conn.close()
         @conn = nil
         raise


### PR DESCRIPTION
Hi,

this bug-fix is due to an error after DB connection, if you use BUFFER in fluentd configuration file with this plugin. 
You have this problem if the connection to DB is already established and after the connection interruption the plugin tries to use the put_copy_end method to send the end-of-data indication to the server, but if the connection doesn't exists or it's was interrupted, plugin can't send request and generates an error.
At this point the only possibility to restore the connection is to restart fluentd process so that the connection is re-established with the DB and the data is send again.

The if on code checks if you have a valid connection or not, if not it resets the connection immediately.
After many tests, it seems to work correctly with the option of Buffer.

![image](https://user-images.githubusercontent.com/43778877/161091567-ceb90758-4847-4c8c-9773-6a6c674876a2.png)

Best regards